### PR TITLE
Set SMTP auth environment vars only if its are non-empty.

### DIFF
--- a/roles/custom/devture_vaultwarden/templates/env.j2
+++ b/roles/custom/devture_vaultwarden/templates/env.j2
@@ -24,8 +24,10 @@ SMTP_FROM={{ devture_vaultwarden_config_smtp_from }}
 SMTP_HOST={{ devture_vaultwarden_config_smtp_host }}
 SMTP_PORT={{ devture_vaultwarden_config_smtp_port }}
 SMTP_SECURITY={{ devture_vaultwarden_config_smtp_security }}
+{% if devture_vaultwarden_config_smtp_username and devture_vaultwarden_config_smtp_password %}
 SMTP_USERNAME={{ devture_vaultwarden_config_smtp_username }}
 SMTP_PASSWORD={{ devture_vaultwarden_config_smtp_password }}
+{% endif %}
 
 ICON_CACHE_FOLDER={{ devture_vaultwarden_config_icon_cache_folder }}
 SENDS_FOLDER={{ devture_vaultwarden_config_sends_folder }}


### PR DESCRIPTION
If SMTP relay server requires authentication the environment variables SMTP_USERNAME and SMTP_PASSWORD must be defined for vaultwarden docker container. But if I want send mail without authentication I should just non export these vars for docker run.
_If you can send emails without logging in, you can simply not set SMTP_USERNAME and SMTP_PASSWORD. [(source)](https://github.com/dani-garcia/vaultwarden/wiki/SMTP-configuration)_
If these variables were set there is no way to disable SMTP auth later via /admin settings page, so we should export its only if both of it have some values.